### PR TITLE
use rb_thread_call_without_gvl

### DIFF
--- a/ext/hermann/extconf.rb
+++ b/ext/hermann/extconf.rb
@@ -146,4 +146,6 @@ dir_config('rdkafka', HEADER_DIRS, LIB_DIRS)
 #   <http://blog.zachallett.com/howto-ruby-c-extension-with-a-static-library>
 $LOCAL_LIBS << File.join(librdkafka.path, 'lib', 'librdkafka.a')
 
+have_func('rb_thread_call_without_gvl')
+
 create_makefile('hermann/hermann_lib')

--- a/ext/hermann/extconf.rb
+++ b/ext/hermann/extconf.rb
@@ -146,6 +146,7 @@ dir_config('rdkafka', HEADER_DIRS, LIB_DIRS)
 #   <http://blog.zachallett.com/howto-ruby-c-extension-with-a-static-library>
 $LOCAL_LIBS << File.join(librdkafka.path, 'lib', 'librdkafka.a')
 
+have_header('ruby/thread.h')
 have_func('rb_thread_call_without_gvl')
 
 create_makefile('hermann/hermann_lib')

--- a/ext/hermann/hermann_lib.c
+++ b/ext/hermann/hermann_lib.c
@@ -33,6 +33,11 @@
 
 #include "hermann_lib.h"
 
+
+/* how long to let librdkafka block on the socket before returning back to the interpreter.
+ * essentially defines how long we wait before consumer_consume_stop_callback() can fire */
+#define CONSUMER_RECVMSG_TIMEOUT_MS 100
+
 /**
  * Convenience function
  *
@@ -358,7 +363,7 @@ void *consumer_recv_msg(void *ptr)
 	rd_kafka_message_t *ret;
 	HermannInstanceConfig *consumerConfig = (HermannInstanceConfig *) ptr;
 
-	ret = rd_kafka_consume(consumerConfig->rkt, consumerConfig->partition, 100);
+	ret = rd_kafka_consume(consumerConfig->rkt, consumerConfig->partition, CONSUMER_RECVMSG_TIMEOUT_MS);
 
 	if ( ret == NULL ) {
 		if ( errno != ETIMEDOUT )

--- a/ext/hermann/hermann_lib.h
+++ b/ext/hermann/hermann_lib.h
@@ -31,7 +31,10 @@
 #define HERMANN_H
 
 #include <ruby.h>
+
+#ifdef HAVE_RUBY_THREAD_H
 #include <ruby/thread.h>
+#endif
 
 #include <ctype.h>
 #include <signal.h>

--- a/ext/hermann/hermann_lib.h
+++ b/ext/hermann/hermann_lib.h
@@ -31,6 +31,7 @@
 #define HERMANN_H
 
 #include <ruby.h>
+#include <ruby/thread.h>
 
 #include <ctype.h>
 #include <signal.h>


### PR DESCRIPTION
this allows threaded code on modern (>=2.0) rubies working.  Also, switch to the single-message form of the rd_kafka call -- the callback form isn't safe to run without the GVL held, as it enters the ruby
interpreter in rb_yield().

is the lookout fork of hermann the current official one? 