### PR TITLE
Unify Consumer#initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,23 +59,43 @@ f.state
 
 Messages can be consumed by calling the consume method and passing a block to handle the yielded messages.  The consume method blocks, so take care to handle that functionality appropriately (i.e. use Concurrent::Promise, Thread, etc).
 
-#### (JRuby-only)
+#### (JRuby)
 ```ruby
 require 'hermann'
 require 'hermann/consumer'
 require 'hermann_jars'
 
-zookeepers = "localhost:2181"
-groupId   = "group1"
 topic     = 'topic'
 new_topic = 'other_topic'
 
-the_consumer = Hermann::Consumer.new(topic, groupId, zookeepers)
+the_consumer = Hermann::Consumer.new(topic, zookeepers: "localhost:2181", group_id: "group1")
 
 the_consumer.consume(new_topic) do |msg|   # can change topic with optional argument to .consume
   puts "Recv: #{msg}"
 end
 ```
+
+
+#### (MRI)
+
+MRI currently has no zookeeper / client group support.
+
+```ruby
+require 'hermann'
+require 'hermann/consumer'
+
+topic     = 'topic'
+new_topic = 'other_topic'
+
+the_consumer = Hermann::Consumer.new(topic, brokers: "localhost:9092", partition: 1)
+
+the_consumer.consume(new_topic) do |msg|   # can change topic with optional argument to .consume
+  puts "Recv: #{msg}"
+end
+```
+
+
+
 
 
 

--- a/lib/hermann/consumer.rb
+++ b/lib/hermann/consumer.rb
@@ -10,30 +10,27 @@ module Hermann
   # Hermann::Consumer provides a simple consumer API which is only safe to be
   # executed in a single thread
   class Consumer
-    attr_reader :topic, :brokers, :partition, :internal
+    attr_reader :topic, :internal
 
 
     # Instantiate Consumer
     #
     # @params [String] kafka topic
-    #
-    # @params [String] group ID
-    #
-    # @params [String] comma separated zookeeper list
-    #
     # @params [Hash] options for Consumer
-    # @option opts [String] :brokers   (for MRI) Comma separated list of brokers
-    # @option opts [Integer] :partition (for MRI) The kafka partition
-    def initialize(topic, groupId, zookeepers, opts={})
+    # @option opts [String]  :brokers    (for MRI) Comma separated list of brokers
+    # @option opts [Integer] :partition  (for MRI) The kafka partition
+    # @option opts [Integer] :zookeepers (for jruby) list of zookeeper servers
+    # @option opts [Integer] :group_id   (for jruby) client group_id
+    #
+    def initialize(topic, opts = {})
       @topic = topic
-      @brokers = brokers
-      @partition = partition
-
       if Hermann.jruby?
-        @internal = Hermann::Provider::JavaSimpleConsumer.new(zookeepers, groupId, topic, opts)
+        zookeepers, group_id = require_values_at(opts, :zookeepers, :group_id)
+
+        @internal = Hermann::Provider::JavaSimpleConsumer.new(zookeepers, group_id, topic, opts)
       else
-        brokers   = opts.delete(:brokers)
-        partition = opts.delete(:partition)
+        brokers, partition = require_values_at(opts, :brokers, :partition)
+
         @internal = Hermann::Lib::Consumer.new(topic, brokers, partition)
       end
     end
@@ -49,6 +46,13 @@ module Hermann
         @internal.shutdown
       else
         #no op
+      end
+    end
+
+    def require_values_at(opts, *args)
+      args.map do |a|
+        raise "Please provide :#{a} option!" unless opts[a]
+        opts[a]
       end
     end
   end

--- a/lib/hermann/consumer.rb
+++ b/lib/hermann/consumer.rb
@@ -52,7 +52,7 @@ module Hermann
     def require_values_at(opts, *args)
       args.map do |a|
         raise "Please provide :#{a} option!" unless opts[a]
-        opts[a]
+        opts.delete(a)
       end
     end
   end

--- a/lib/hermann/version.rb
+++ b/lib/hermann/version.rb
@@ -1,3 +1,3 @@
 module Hermann
-  VERSION = '0.22.0'
+  VERSION = '0.23.0'
 end

--- a/scripts/consume_msgs_loop_localhost.rb
+++ b/scripts/consume_msgs_loop_localhost.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'lib/hermann'
 require 'lib/hermann/consumer'
 
-c = Hermann::Consumer.new( "lms_messages", "localhost:9092", 0 )
+c = Hermann::Consumer.new( "lms_messages", :zookeepers => "localhost:2181", :group_id => "lms_message_consumer" )
 t1 = 0
 c.consume() do
   |msg| puts("Received: #{msg}")

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -4,7 +4,7 @@ require 'hermann/consumer'
 # XXX: Hermann::Consumer isn't really supported anywhere, MRI included right
 # now
 describe Hermann::Consumer do
-  subject(:consumer) { described_class.new(topic, nil, nil, opts) }
+  subject(:consumer) { described_class.new(topic, opts) }
 
   let(:topic) { 'rspec' }
   let(:brokers) { 'localhost:1337' }
@@ -46,7 +46,7 @@ describe Hermann::Consumer do
   end
 
   context 'on Jruby', :platform => :java do
-    subject(:consumer) { described_class.new(topic, groupId, zookeepers) }
+    subject(:consumer) { described_class.new(topic, group_id: groupId, zookeepers: zookeepers) }
 
     let(:zookeepers) { 'localhost:2181' }
     let(:groupId)    { 'groupId' }


### PR DESCRIPTION
this is a breaking change for Consumer#initialize, but it brings a bit of unity to the JRuby / MRI code paths -- they can share the `topic` argument, and everything else gets passed in through an options hash.

