### PR TITLE
1.9.3 fixes

### DIFF
--- a/ext/hermann/extconf.rb
+++ b/ext/hermann/extconf.rb
@@ -147,6 +147,8 @@ dir_config('rdkafka', HEADER_DIRS, LIB_DIRS)
 $LOCAL_LIBS << File.join(librdkafka.path, 'lib', 'librdkafka.a')
 
 have_header('ruby/thread.h')
+have_header('ruby/intern.h')
+have_func('rb_thread_blocking_region')
 have_func('rb_thread_call_without_gvl')
 
 create_makefile('hermann/hermann_lib')

--- a/ext/hermann/hermann_lib.c
+++ b/ext/hermann/hermann_lib.c
@@ -337,7 +337,7 @@ void consumer_init_kafka(HermannInstanceConfig* config) {
 
 // Ruby gem extensions
 
-#if defined(RB_THREAD_BLOCKING_REGION) || defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
+#if defined(HAVE_RB_THREAD_BLOCKING_REGION) || defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
 /* NOTE: We only need this method defined if RB_THREAD_BLOCKING_REGION is
  * defined, otherwise it's unused
  */
@@ -396,8 +396,8 @@ static void consumer_consume_loop(HermannInstanceConfig* consumerConfig) {
 	TRACER("\n");
 
 	while (consumerConfig->run) {
-#ifdef RB_THREAD_BLOCKING_REGION
-		msg = rb_thread_blocking_region(consumer_recv_msg,
+#ifdef HAVE_RB_THREAD_BLOCKING_REGION
+		msg = (rd_kafka_message_t *) rb_thread_blocking_region((rb_blocking_function_t *) consumer_recv_msg,
 				consumerConfig,
 				consumer_consume_stop_callback,
 				consumerConfig);

--- a/ext/hermann/hermann_lib.h
+++ b/ext/hermann/hermann_lib.h
@@ -36,6 +36,10 @@
 #include <ruby/thread.h>
 #endif
 
+#ifdef HAVE_RUBY_INTERN_H
+#include <ruby/intern.h>
+#endif
+
 #include <ctype.h>
 #include <signal.h>
 #include <string.h>


### PR DESCRIPTION
1.9.3 seems like it should actually still be using the rb_thread_blocking_region() call, as ...call_without_gvl() isn't defined in any header (although it is available).

Consuming that implicit declaration was causing crashes in my production, although not, interestingly, in travis.