### PR TITLE
Fix TypeError conversion of Array into String

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ RSpec.configure do |c|
 
   shared_context 'integration test context', :type => :integration do
     let(:topic) { "hermann_testing_" + rand(100_000_000).to_s }
-    let(:brokers) { $integrationconf['kafka']['brokers'] }
+    let(:brokers) { $integrationconf['kafka']['brokers'].join(',') }
     let(:zookeepers) { $integrationconf['zookeepers'] }
   end
 end


### PR DESCRIPTION
When running rake spec:integration with /fixtures/integration.yml

Hermann::Lib::Producer #connect should connect
     Failure/Error: subject(:producer) { Hermann::Lib::Producer.new(brokers) }
     TypeError: no implicit conversion of Array into String
     # ./spec/hermann_lib/producer_spec.rb:10:in `initialize'