### PR TITLE
Add the ability to request cluster / topic metadata from the brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ promise.state                          # the state of the promise
 require 'hermann/producer'
 
 p = Hermann::Producer.new('topic', ['localhost:6667'])  # arguments topic, list of brokers
-f = p.push('hello world from mri')                    
-f.state                                               
-p.tick_reactor                                        
+f = p.push('hello world from mri')
+f.state
+p.tick_reactor
 f.state
 ```
 
@@ -94,8 +94,18 @@ the_consumer.consume(new_topic) do |msg|   # can change topic with optional argu
 end
 ```
 
+### Metadata request (MRI-only)
 
+Topic and cluster metadata may be retrieved in the MRI version by querying the Kafka brokers.
 
+```ruby
+require 'hermann'
+require 'hermann/discovery/metadata'
+
+c = Hermann::Discovery::Metadata.new( "localhost:9092" )
+puts c.get_topics.inspect
+puts c.get_topics("only_this_topic").inspect
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,14 @@ require 'hermann'
 require 'hermann/discovery/metadata'
 
 c = Hermann::Discovery::Metadata.new( "localhost:9092" )
-puts c.get_topics.inspect
-puts c.get_topics("only_this_topic").inspect
+topic = c.topic("topic")
+
+puts topic.partitions.first
+
+consumers = topic.partitions.map do |partition|
+  partition.consumer
+end
+
 ```
 
 

--- a/ext/hermann/hermann_lib.c
+++ b/ext/hermann/hermann_lib.c
@@ -778,7 +778,7 @@ static VALUE producer_metadata_make_hash(struct rd_kafka_metadata *data)
 
 		for ( j = 0 ; j < data->topics[i].partition_cnt ; j++ ) {
 			VALUE partition_hash = rb_hash_new();
-			rd_kafka_metadata_partition_t *partition = &(data->topics[i].partitions[i]);
+			rd_kafka_metadata_partition_t *partition = &(data->topics[i].partitions[j]);
 
 			/* id => 1, leader_id => 0 */
 			rb_hash_aset(partition_hash, ID2SYM(rb_intern("id")), INT2FIX(partition->id));

--- a/ext/hermann/hermann_lib.c
+++ b/ext/hermann/hermann_lib.c
@@ -725,6 +725,7 @@ static VALUE producer_connect(VALUE self, VALUE timeout) {
 
 	md_context.rk = producerConfig->rk;
 	md_context.topic = NULL;
+	md_context.data = NULL;
 	md_context.timeout_ms = rb_num2int(timeout);
 
 	err = producer_metadata_request(&md_context);
@@ -742,7 +743,8 @@ static VALUE producer_connect(VALUE self, VALUE timeout) {
 		producerConfig->isErrored = err;
 	}
 
-	rd_kafka_metadata_destroy(md_context.data);
+	if ( md_context.data )
+		rd_kafka_metadata_destroy(md_context.data);
 
 	return result;
 }

--- a/ext/hermann/hermann_lib.h
+++ b/ext/hermann/hermann_lib.h
@@ -113,4 +113,11 @@ typedef struct {
 	VALUE result;
 } hermann_push_ctx_t;
 
+typedef struct {
+	rd_kafka_t *rk;
+	rd_kafka_topic_t *topic;
+	struct rd_kafka_metadata *data;
+	int timeout_ms;
+} hermann_metadata_ctx_t;
+
 #endif

--- a/lib/hermann/discovery/metadata.rb
+++ b/lib/hermann/discovery/metadata.rb
@@ -12,7 +12,7 @@ module Hermann
       Topic     = Struct.new(:name, :partitions)
 
       Partition = Struct.new(:id, :leader, :replicas, :insync_replicas, :topic_name) do
-        def consumer(offset: :end)
+        def consumer(offset=:end)
           Hermann::Consumer.new(topic_name, brokers: ([leader] + replicas).join(','), partition: id, offset: offset)
         end
       end

--- a/lib/hermann/discovery/metadata.rb
+++ b/lib/hermann/discovery/metadata.rb
@@ -1,0 +1,16 @@
+require 'hermann_lib'
+
+module Hermann
+  module Discovery
+    class Metadata
+      def initialize(brokers)
+        raise "this is an MRI api only!" if Hermann.jruby?
+        @internal = Hermann::Lib::Producer.new(brokers)
+      end
+
+      def get_topics
+        @internal.metadata(nil, 200)
+      end
+    end
+  end
+end

--- a/lib/hermann/discovery/metadata.rb
+++ b/lib/hermann/discovery/metadata.rb
@@ -3,7 +3,12 @@ require 'hermann_lib'
 module Hermann
   module Discovery
     class Metadata
-      Broker    = Struct.new(:id, :host, :port)
+      Broker    = Struct.new(:id, :host, :port) do
+        def to_s
+          "#{host}:#{port}"
+        end
+      end
+
       Topic     = Struct.new(:name, :partitions)
       Partition = Struct.new(:id, :leader, :replicas, :insync_replicas)
 

--- a/lib/hermann/discovery/metadata.rb
+++ b/lib/hermann/discovery/metadata.rb
@@ -3,13 +3,14 @@ require 'hermann_lib'
 module Hermann
   module Discovery
     class Metadata
+      TIMEOUT_MS = 200
       def initialize(brokers)
         raise "this is an MRI api only!" if Hermann.jruby?
         @internal = Hermann::Lib::Producer.new(brokers)
       end
 
-      def get_topics
-        @internal.metadata(nil, 200)
+      def get_topics(filter_topics = nil)
+        @internal.metadata(filter_topics, TIMEOUT_MS)
       end
     end
   end

--- a/lib/hermann/discovery/metadata.rb
+++ b/lib/hermann/discovery/metadata.rb
@@ -3,15 +3,59 @@ require 'hermann_lib'
 module Hermann
   module Discovery
     class Metadata
+      Broker    = Struct.new(:id, :host, :port)
+      Topic     = Struct.new(:name, :partitions)
+      Partition = Struct.new(:id, :leader, :replicas, :insync_replicas)
+
       TIMEOUT_MS = 200
       def initialize(brokers)
         raise "this is an MRI api only!" if Hermann.jruby?
         @internal = Hermann::Lib::Producer.new(brokers)
       end
 
-      def get_topics(filter_topics = nil)
-        @internal.metadata(filter_topics, TIMEOUT_MS)
+      #
+      # @internal.metadata returns:
+      # {:brokers => [{:id=>3, :host=>"kafka3.alpha4.sac1.zdsys.com", :port=>9092}],
+      #  :topics  => {"testtopic"=>[{:id=>0, :leader_id=>3, :replica_ids=>[3, 1],  :isr_ids=>[3, 1]}}}
+      #
+      def brokers
+        brokers_from_metadata(@internal.metadata("", TIMEOUT_MS))
       end
+
+      def topics(filter_topics = nil)
+        md = @internal.metadata(filter_topics, TIMEOUT_MS)
+
+        broker_hash = brokers_from_metadata(md).inject({}) do |h, broker|
+          h[broker.id] = broker
+          h
+        end
+
+        md[:topics].inject({}) do |topic_hash, arr|
+          topic_name, raw_partitions = *arr
+          partitions = raw_partitions.map do |p|
+            leader       = broker_hash[p[:leader_id]]
+            all_replicas = p[:replica_ids].map { |i| broker_hash[i] }
+            isr_replicas = p[:isr_ids].map { |i| broker_hash[i] }
+            Partition.new(p[:id], leader, all_replicas, isr_replicas)
+          end
+
+          topic_hash[topic_name] = Topic.new(topic_name, partitions)
+          topic_hash
+        end
+      end
+
+      def topic(t)
+        topics(t)[t]
+      end
+
+      private
+
+      def brokers_from_metadata(md)
+        md[:brokers].map do |h|
+          Broker.new(h[:id], h[:host], h[:port])
+        end
+      end
+
     end
   end
 end

--- a/lib/hermann/discovery/metadata.rb
+++ b/lib/hermann/discovery/metadata.rb
@@ -19,7 +19,7 @@ module Hermann
       #  :topics  => {"testtopic"=>[{:id=>0, :leader_id=>3, :replica_ids=>[3, 1],  :isr_ids=>[3, 1]}}}
       #
       def brokers
-        brokers_from_metadata(@internal.metadata("", TIMEOUT_MS))
+        brokers_from_metadata(@internal.metadata(nil, TIMEOUT_MS))
       end
 
       def topics(filter_topics = nil)

--- a/scripts/metadata_mri.rb
+++ b/scripts/metadata_mri.rb
@@ -1,8 +1,15 @@
 require 'bundler/setup'
 require 'hermann'
 require 'hermann/discovery/metadata'
+require 'hermann/consumer'
 
 c = Hermann::Discovery::Metadata.new( "localhost:9092" )
 c.topic("maxwell")
 puts c.topic("maxwell").inspect
 
+
+puts c.brokers.inspect
+consumer = Hermann::Consumer.new("maxwell", brokers: "localhost:9092, localhost:9092", partition: c.topic('maxwell').partitions.first.id, offset: :start)
+consumer.consume do |c|
+  puts c
+end

--- a/scripts/metadata_mri.rb
+++ b/scripts/metadata_mri.rb
@@ -3,5 +3,5 @@ require 'hermann'
 require 'hermann/discovery/metadata'
 
 c = Hermann::Discovery::Metadata.new( "localhost:9092" )
-puts c.get_topics.inspect
+puts c.get_topics("maxwell").inspect
 

--- a/scripts/metadata_mri.rb
+++ b/scripts/metadata_mri.rb
@@ -3,5 +3,6 @@ require 'hermann'
 require 'hermann/discovery/metadata'
 
 c = Hermann::Discovery::Metadata.new( "localhost:9092" )
-puts c.get_topics("maxwell").inspect
+c.topic("maxwell")
+puts c.topic("maxwell").inspect
 

--- a/scripts/metadata_mri.rb
+++ b/scripts/metadata_mri.rb
@@ -1,0 +1,7 @@
+require 'bundler/setup'
+require 'hermann'
+require 'hermann/discovery/metadata'
+
+c = Hermann::Discovery::Metadata.new( "localhost:9092" )
+puts c.get_topics.inspect
+


### PR DESCRIPTION
First I implemented the low-level `Hermann::Lib::Producer#metadata`, which returns a hash describing the cluster state.  I then refactored the existing metadata request to use the same (non-blocking) codepath. 

Then, I wrapped the whole thing up in a relatively decent-looking ruby api.

