### PR TITLE
Better postloop cleanup

### DIFF
--- a/ext/hermann/hermann_lib.c
+++ b/ext/hermann/hermann_lib.c
@@ -259,6 +259,7 @@ static void msg_consume(rd_kafka_message_t *rkmessage, HermannInstanceConfig *cf
 	// Yield the data to the Consumer's block
 	if (rb_block_given_p()) {
 		VALUE value = rb_str_new((char *)rkmessage->payload, rkmessage->len);
+		rd_kafka_message_destroy(rkmessage);
 		rb_yield(value);
 	}
 	else {
@@ -412,7 +413,6 @@ static void consumer_consume_loop(HermannInstanceConfig* consumerConfig) {
 
 		if ( msg ) {
 			msg_consume(msg, consumerConfig);
-			rd_kafka_message_destroy(msg);
 		}
 	}
 }


### PR DESCRIPTION
I'm working on a script that does some bisection on the kafka stream to find a timestamp.  to this end, I need to dip in and out of `consume()` a bunch.  Here's a couple of fixes related to that:

- call rd_kafka_message_destroy right before rb_yield()

if rb_yield() ends in a "break" statement, it never returns control back to the caller; thus we'd leak the message

- ensure we call consumer_consume_loop_stop at the end of the loop …

we need rb_ensure so that if the loop terminates in a "break" statement we'll still call rd_kafka_consume_stop