### PR TITLE
Add support for passing partition_key in MRI

### DIFF
--- a/ext/hermann/hermann_rdkafka.c
+++ b/ext/hermann/hermann_rdkafka.c
@@ -32,6 +32,10 @@
 /* Much of the librdkafka library calls were lifted from rdkafka_example.c */
 
 #include "hermann_rdkafka.h"
+
+/* This header file exposes the functions in librdkafka.a that are needed for
+ * consistent partitioning. After librdkafka releases a new tag and Hermann
+ * points to it, this can be removed. */
 #include "rdcrc32.h"
 
 #ifdef HAVE_RUBY_VERSION_H
@@ -136,6 +140,8 @@ static void msg_delivered(rd_kafka_t *rk,
 }
 
 
+/* This function is in rdkafka.h on librdkafka master. As soon as a new
+ * version is released and Hermann points to it, this can be removed. */
 int32_t rd_kafka_msg_partitioner_consistent (const rd_kafka_topic_t *rkt,
 											 const void *key, size_t keylen,
 											 int32_t partition_cnt,

--- a/ext/hermann/rdcrc32.h
+++ b/ext/hermann/rdcrc32.h
@@ -1,0 +1,103 @@
+/**
+ * \file rdcrc32.h
+ * Functions and types for CRC checks.
+ *
+ * Generated on Tue May  8 17:36:59 2012,
+ * by pycrc v0.7.10, http://www.tty1.net/pycrc/
+ *
+ * NOTE: Contains librd modifications:
+ *       - rd_crc32() helper.
+ *       - __RDCRC32___H__ define (was missing the '32' part).
+ *
+ * using the configuration:
+ *    Width        = 32
+ *    Poly         = 0x04c11db7
+ *    XorIn        = 0xffffffff
+ *    ReflectIn    = True
+ *    XorOut       = 0xffffffff
+ *    ReflectOut   = True
+ *    Algorithm    = table-driven
+ *****************************************************************************/
+#ifndef __RDCRC32___H__
+#define __RDCRC32___H__
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * The definition of the used algorithm.
+ *****************************************************************************/
+#define CRC_ALGO_TABLE_DRIVEN 1
+
+
+/**
+ * The type of the CRC values.
+ *
+ * This type must be big enough to contain at least 32 bits.
+ *****************************************************************************/
+typedef uint32_t rd_crc32_t;
+
+
+/**
+ * Reflect all bits of a \a data word of \a data_len bytes.
+ *
+ * \param data         The data word to be reflected.
+ * \param data_len     The width of \a data expressed in number of bits.
+ * \return             The reflected data.
+ *****************************************************************************/
+rd_crc32_t rd_crc32_reflect(rd_crc32_t data, size_t data_len);
+
+
+/**
+ * Calculate the initial crc value.
+ *
+ * \return     The initial crc value.
+ *****************************************************************************/
+static inline rd_crc32_t rd_crc32_init(void)
+{
+    return 0xffffffff;
+}
+
+
+/**
+ * Update the crc value with new data.
+ *
+ * \param crc      The current crc value.
+ * \param data     Pointer to a buffer of \a data_len bytes.
+ * \param data_len Number of bytes in the \a data buffer.
+ * \return         The updated crc value.
+ *****************************************************************************/
+rd_crc32_t rd_crc32_update(rd_crc32_t crc, const unsigned char *data, size_t data_len);
+
+
+/**
+ * Calculate the final crc value.
+ *
+ * \param crc  The current crc value.
+ * \return     The final crc value.
+ *****************************************************************************/
+static inline rd_crc32_t rd_crc32_finalize(rd_crc32_t crc)
+{
+    return crc ^ 0xffffffff;
+}
+
+
+/**
+ * Wrapper for performing CRC32 on the provided buffer.
+ */
+static inline rd_crc32_t rd_crc32 (const char *data, size_t data_len) {
+  return rd_crc32_finalize(rd_crc32_update(rd_crc32_init(),
+             (const unsigned char *)data,
+             data_len));
+}
+
+#ifdef __cplusplus
+}           /* closing brace for extern "C" */
+#endif
+
+#endif      /* __RDCRC32___H__ */

--- a/lib/hermann/producer.rb
+++ b/lib/hermann/producer.rb
@@ -64,7 +64,7 @@ module Hermann
 
       if Hermann.jruby?
         key = opts.has_key?(:partition_key) ? opts[:partition_key].to_java : nil
-        result = @internal.push_single(value, topic, key)
+        result = @internal.push_single(value, topic, key, nil)
         unless result.nil?
           @children << result
         end
@@ -76,7 +76,7 @@ module Hermann
         # librdkafka callback queue overflow
         tick_reactor
         result = create_result
-        @internal.push_single(value, topic, result)
+        @internal.push_single(value, topic, opts[:partition_key].to_s, result)
       end
 
       return result

--- a/lib/hermann/producer.rb
+++ b/lib/hermann/producer.rb
@@ -63,8 +63,7 @@ module Hermann
       end
 
       if Hermann.jruby?
-        key = opts.has_key?(:partition_key) ? opts[:partition_key].to_java : nil
-        result = @internal.push_single(value, topic, key, nil)
+        result = @internal.push_single(value, topic, opts[:partition_key], nil)
         unless result.nil?
           @children << result
         end

--- a/lib/hermann/provider/java_producer.rb
+++ b/lib/hermann/provider/java_producer.rb
@@ -43,7 +43,7 @@ module Hermann
       # @return +Concurrent::Promise+ Representa a promise to send the
       #   data to the kafka broker.  Upon execution the Promise's status
       #   will be set
-      def push_single(msg, topic, key)
+      def push_single(msg, topic, key, _)
         Concurrent::Promise.execute {
           data = ProducerUtil::KeyedMessage.new(topic, nil, key, msg.to_java_bytes)
           begin

--- a/lib/hermann/provider/java_producer.rb
+++ b/lib/hermann/provider/java_producer.rb
@@ -44,6 +44,7 @@ module Hermann
       #   data to the kafka broker.  Upon execution the Promise's status
       #   will be set
       def push_single(msg, topic, key, _)
+        key = key && key.to_java
         Concurrent::Promise.execute {
           data = ProducerUtil::KeyedMessage.new(topic, nil, key, msg.to_java_bytes)
           begin

--- a/spec/hermann_lib/producer_spec.rb
+++ b/spec/hermann_lib/producer_spec.rb
@@ -41,7 +41,7 @@ describe 'Hermann::Provider::RDKafka::Producer', :platform => :mri do
       let(:brokers) { 'localhost:13337' }
 
       it 'should error after attempting to connect' do |example|
-        producer.push_single(example.full_description, 'test-topic', nil)
+        producer.push_single(example.full_description, 'test-topic', '', nil)
         begin
           producer.tick(timeout)
         rescue StandardError => ex
@@ -62,7 +62,7 @@ describe 'Hermann::Provider::RDKafka::Producer', :platform => :mri do
 
   describe '#push_single', :type => :integration do
     let(:message) { |example| example.full_description }
-    subject(:push) { producer.push_single(message, topic, nil) }
+    subject(:push) { producer.push_single(message, topic, '', nil) }
 
     it 'should return' do
       expect(push).not_to be_nil
@@ -105,7 +105,7 @@ describe 'Hermann::Provider::RDKafka::Producer', :platform => :mri do
 
     context 'with a single queued request' do
       before :each do
-        producer.push_single('hello', topic, nil)
+        producer.push_single('hello', topic, '', nil)
       end
 
       it 'should return successfully' do

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -43,26 +43,26 @@ describe Hermann::Producer do
 
     context 'without topic passed' do
       it 'uses initialized topic' do
-        expect(producer.internal).to receive(:push_single).with(msg, topic, anything)
+        expect(producer.internal).to receive(:push_single).with(msg, topic, anything, anything)
         producer.push(msg)
       end
     end
     context 'without topic passed', :platform => :java do
       it 'uses initialized topic and does not have a partition key' do
-        expect(producer.internal).to receive(:push_single).with(msg, topic, nil)
+        expect(producer.internal).to receive(:push_single).with(msg, topic, nil, anything)
         producer.push(msg)
       end
     end
     context 'with topic passed' do
       it 'can change topic' do
-        expect(producer.internal).to receive(:push_single).with(msg, passed_topic, anything)
+        expect(producer.internal).to receive(:push_single).with(msg, passed_topic, anything, anything)
         producer.push(msg, :topic => passed_topic)
       end
 
       context 'and an array of messags' do
         it 'should propagate the topic' do
           messages = 3.times.map { |i| msg }
-          expect(producer.internal).to receive(:push_single).with(msg, passed_topic, anything).exactly(messages.size).times
+          expect(producer.internal).to receive(:push_single).with(msg, passed_topic, anything, anything).exactly(messages.size).times
           producer.push(messages, :topic => passed_topic)
         end
       end
@@ -70,7 +70,13 @@ describe Hermann::Producer do
 
     context 'with explicit partition key', :platform => :java do
       it 'uses the partition key' do
-        expect(producer.internal).to receive(:push_single).with(msg, topic, partition_key.to_java)
+        expect(producer.internal).to receive(:push_single).with(msg, topic, partition_key.to_java, anything)
+        producer.push(msg, :partition_key => partition_key)
+      end
+    end
+    context 'with explicit partition key', :platform => :mri do
+      it 'uses the partition key' do
+        expect(producer.internal).to receive(:push_single).with(msg, topic, partition_key, anything)
         producer.push(msg, :partition_key => partition_key)
       end
     end
@@ -178,7 +184,7 @@ describe Hermann::Producer do
 
         it 'should invoke #push_single for each element' do
           value.each do |v|
-            expect(producer.internal).to receive(:push_single).with(v, topic, anything)
+            expect(producer.internal).to receive(:push_single).with(v, topic, anything, anything)
           end
 
           expect(result).to be_instance_of Array

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -68,13 +68,7 @@ describe Hermann::Producer do
       end
     end
 
-    context 'with explicit partition key', :platform => :java do
-      it 'uses the partition key' do
-        expect(producer.internal).to receive(:push_single).with(msg, topic, partition_key.to_java, anything)
-        producer.push(msg, :partition_key => partition_key)
-      end
-    end
-    context 'with explicit partition key', :platform => :mri do
+    context 'with explicit partition key' do
       it 'uses the partition key' do
         expect(producer.internal).to receive(:push_single).with(msg, topic, partition_key, anything)
         producer.push(msg, :partition_key => partition_key)

--- a/spec/providers/java_producer_spec.rb
+++ b/spec/providers/java_producer_spec.rb
@@ -8,11 +8,11 @@ describe Hermann::Provider::JavaProducer, :platform => :java  do
   let(:topic)      { 'rspec' }
   let(:brokers)    { '0:1337'}
   let(:opts)       { {} }
-  let(:part_key)   { "key".to_java }
+  let(:part_key)   { "key" }
   let(:msg)        { "bar" }
 
   describe '#push_single' do
-    subject(:result) { producer.push_single(msg, topic, nil) }
+    subject(:result) { producer.push_single(msg, topic, nil, nil) }
 
     let(:passed_topic) { 'foo' }
 
@@ -22,18 +22,18 @@ describe Hermann::Provider::JavaProducer, :platform => :java  do
 
     it 'can change topic' do
       expect(Hermann::ProducerUtil::KeyedMessage).to receive(:new).with(passed_topic, nil, nil, anything)
-      producer.push_single(msg, passed_topic, nil).wait(1)
+      producer.push_single(msg, passed_topic, nil, nil).wait(1)
     end
 
     it 'can change partition key' do
       expect(Hermann::ProducerUtil::KeyedMessage).to receive(:new).with(passed_topic, nil, part_key, anything)
-      producer.push_single(msg, passed_topic, part_key).wait(1)
+      producer.push_single(msg, passed_topic, part_key, nil).wait(1)
     end
 
     context 'error conditions' do
       shared_examples 'an error condition' do
         it 'should be rejected' do
-          promise = producer.push_single('rspec', topic, nil).wait(1)
+          promise = producer.push_single('rspec', topic, nil, nil).wait(1)
           expect(promise).to be_rejected
           expect { promise.value! }.to raise_error
         end


### PR DESCRIPTION
This PR adds support for consistent partitioning to MRI. The code chooses a consistent partition based on the hash of the :partition_key (CRC32). In the case where :partition_key is nil or an empty string, then it chooses a random partition.

The routines to compute a consistent hash were already in librdkafka, though they weren't exposed in the rdkafka.h header file, so we copied rdcrc32.h. I believe a later release of librdkafka may expose the rd_kafka_msg_partitioner_consistent function, but I don't think there is a tag with it, yet.